### PR TITLE
node/browserify compatibility

### DIFF
--- a/build/dom-class.node.js
+++ b/build/dom-class.node.js
@@ -231,5 +231,5 @@ var DOMClass = (function (g, A, O) {'use strict';
     dP(Element.prototype, CONSTRUCTOR, {value: CustomElement});
     return CustomElement;
   };
-}(this.window || global, Array, Object));
+}(window || global, Array, Object));
 module.exports = DOMClass;

--- a/src/dom-class.js
+++ b/src/dom-class.js
@@ -205,4 +205,4 @@ var DOMClass = (function (g, A, O) {'use strict';
     dP(Element.prototype, CONSTRUCTOR, {value: CustomElement});
     return CustomElement;
   };
-}(this.window || global, Array, Object));
+}(window || global, Array, Object));


### PR DESCRIPTION
The following:

``` javascript
var DOMClass = require('dom-class');
```

..results in the browser console: Cannot read property 'window' of undefined

It's from the last line of _dom-class.js_:

``` javascript
}(this.window || global, Array, Object));
```

So `this.window` was changed to `window`.
